### PR TITLE
Add missing QDataStream include to fix building with Qt 5.5+

### DIFF
--- a/PInterface/QtSingleApplication/qtlocalpeer.cpp
+++ b/PInterface/QtSingleApplication/qtlocalpeer.cpp
@@ -41,6 +41,7 @@
 
 #include "qtlocalpeer.h"
 #include <QCoreApplication>
+#include <QDataStream>
 #include <QTime>
 
 #if defined(Q_OS_WIN)


### PR DESCRIPTION
Signed-off-by: Felix Yan felixonmars@archlinux.org
